### PR TITLE
AAP-35593 - add: unit tests to dcvs checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# Implementing in another Repo
+
 This action validates the following in a PR:
 1. A commit in the pull request has the JIRA issue key in the commit message. Note, that the commit cannot be a merge commit.
 1. The JIRA issue key is at the beginning of the pull request title.
@@ -21,3 +23,21 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 ```
+
+
+# Testing locally
+
+In order to test locally we need to set an environment variable called `PULL_REQUEST`. 
+This can be accomplished by doing a curl command (change <repo> and <pull number> to match what you want to test):
+```
+export PULL_REQUEST=$(curl https://api.github.com/repos/ansible/<repo>/pulls/<pull number>)
+```
+
+After that is set you can run the python scrip with the `--dry-run` command to prevent it from trying to update the PR you are testing:
+```
+./check_dvcs.py --dry-run
+```
+
+This will add additional debugging statements as well as not trying to modify the PR.
+
+NOTE: this will use unauthenticated GitHub API requests which are throttled by default. If you hit your limit you will need to wait until your counter resets to test again.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Implementing in another Repo
+# Usage
 
 This action validates the following in a PR:
 1. A commit in the pull request has the JIRA issue key in the commit message. Note, that the commit cannot be a merge commit.

--- a/README.md
+++ b/README.md
@@ -6,11 +6,13 @@ This action validates the following in a PR:
 To use this action create a github workflow like:
 ```yaml
 on:
-  pull_request:
-    types: [opened, edited, reopened, synchronize]
-
+  pull_request_target:
+    type: opened, synchronize, reopened, edited
 jobs:
   dvcs_pr_checker:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     name: Check the PR for DVCS integration
     steps:
@@ -18,5 +20,4 @@ jobs:
         uses: ansible/dvcs-action@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-
 ```

--- a/check_dvcs.py
+++ b/check_dvcs.py
@@ -116,13 +116,21 @@ def make_decisions(
 
     decisions = [comment_preamble]
     # Now make th decisions if this is in good order....
+
+    # First check the PR title
     if not pr_title_jira:
         # If there is no PR title JIRA report bad
         decisions.append(f"* {bad_icon} Title: PR title does not start with a JIRA number (AAP-[0-9]+) or {_NO_JIRA_MARKER}")
+    elif pr_title_jira == _NO_JIRA_MARKER.lower():
+        # If we put the _NO_JIRA_MARKER in the title that is good enough.
+        # it provides the lowest entry barrier for community as they wouldn't have to fix branches or commit messages
+        decisions.append(f"* {good_icon} Title: reported no jira related, no other checks necessary")
+        return "\n".join(decisions)
     else:
         # Report the title is good
         decisions.append(f"* {good_icon} Title: JIRA number {pr_title_jira}")
 
+    # Next check the source branch
     if not source_branch_jira:
         # If there is no Source Branch JIRA report bad
         decisions.append(f"* {bad_icon} Source Branch: The source branch of the PR does not start with a JIRA number (AAP-[0-9]+) or {_NO_JIRA_MARKER}")
@@ -130,10 +138,12 @@ def make_decisions(
         # Report the source branch is good
         decisions.append(f"* {good_icon} Source Branch: JIRA number {source_branch_jira}")
 
+    # Now compare the source branch to the pr title
     if pr_title_jira is not None and source_branch_jira is not None and pr_title_jira != source_branch_jira:
         # If we have source and title JIRAS and there is a mismatch between the title and source branch JIRAs report the mismatch
         decisions.append(f"* {bad_icon} Mismatch: The JIRAs in the source branch {source_branch_jira} and title {pr_title_jira} do not match!")
 
+    # Finally lets check the commits
     if len(possible_commit_jiras) == 0:
         # If we got no commit JIRAS the commits are bad
         decisions.append(f"* {bad_icon} Commits: No commits with a JIRA number (AAP-[0-9]+) or {_NO_JIRA_MARKER} found!")

--- a/test_check_dvcs.py
+++ b/test_check_dvcs.py
@@ -15,13 +15,15 @@ class TestDoesStringStartWithJira:
         [
             ("testing", None),
             (f'{check_dvcs._NO_JIRA_MARKER} other stuff', check_dvcs._NO_JIRA_MARKER),
-            ('AAP-1234 other stuff', 'AAP-1234'),
+            ('AAP-2222 other stuff', 'AAP-2222'),
+            ('other stuff AAP-3333', None),
+            ('other stuff AAP-4444 jira in the middle', None),
         ],
     )
     def test_does_string_start_with_jira_function(self, input, expected_return):
         result = check_dvcs.does_string_start_with_jira(input)
         assert result == expected_return
-
+        print('aqui', result)
 
 class TestGetPreviousCommentsUrls:
 
@@ -237,8 +239,6 @@ class TestMakeDecisions:
     # test scenarios (happy path)
     # PR has NO_JIRA_MARKER, Commit has NO_JIRA_MARKER, SB has NO_JIRA_MARKER,
     # PR has a valid JIRA marker, commit has a valid Jira marker, SB has a valid JIRA marker
-    # Commit has _NO_JIRA_MARKER
-    # Validate upper case/lower case JIRA markers
 
     @pytest.mark.parametrize(
         "pr_title_jira,possible_commit_jiras,source_branch_jira",
@@ -249,24 +249,9 @@ class TestMakeDecisions:
                 f'{check_dvcs._NO_JIRA_MARKER}',
             ),
             (
-                'AAP-1234',
-                ['AAP-1234', f"{check_dvcs._NO_JIRA_MARKER} no marker", 'AAP-5678 Some other marker but only one has to be valid'],
-                'aap-1234',
-            ),
-            (
-                'AAP-1234',
-                ['AAP-1234', 'AAP-1234 testing valid marker', f"{check_dvcs._NO_JIRA_MARKER} Testing valid marker"],
-                'aap-1234',
-            ),
-            (
-                'AAP-1234',
-                ['AAP-1234', 'AAP-1234 testing valid marker', 'AAP-1234 testing valid marker'],
-                'aap-1234',
-            ),
-            (
-                'aap-1234',
-                ['aap-1234', 'aap-1234 testing valid marker', 'aap-1234 testing valid marker'],
-                'aap-1234',
+                'AAP-5678',
+                ['AAP-5678', f"{check_dvcs._NO_JIRA_MARKER} no marker", 'AAP-5678'],
+                'aap-5678',
             ),
         ],
     )
@@ -336,13 +321,13 @@ class TestMakeDecisions:
                 'ABCDE-1234',  # source accepts different types of JIRA formats.
                 f"* {check_dvcs.bad_icon} Mismatch: The JIRAs in the source branch",
             ),
-            (  # Validate AAP-1234 marker format
-                'AAP-1234 this is a title',
-                ['AAP-1234', 'aap-1234', 'AAp-1234'],
-                'aap-1234 this is the source branch',
+            (  # Validate low and upper case AAP-1234 marker format
+                'AAP-9009 this is a title',
+                ['AAP-9009', 'aap-9009', 'AAp-9009'],
+                'aap-9009 this is the source branch',
                 f"* {check_dvcs.bad_icon} Mismatch: The JIRAs in the source branch",
             ),
-            (  # Validate AAP-1234 marker format
+            (  # Validate AAP-1234 same marker format
                 'AAP-1234 this is a title',
                 ['AAP-1234', 'aap-1234', 'aAp-1234'],
                 'aap-1234 this is the source branch',
@@ -370,12 +355,12 @@ class TestMakeDecisions:
             "Source branch is none",
             "Source branch does not match jira PR",
             "Source branch does not match expected format",
-            "Validate AAP-1234 marker format",
-            "Validate AAP-1234 marker format",
+            "Validate low and upper case AAP-1234 marker format",
+            "Validate AAP-1234 same marker format",
             "Validate AAP-1234 marker format",
             "Commit: no commits with a Jira number"
         ],
     )
-    def test_bad_result(self, pr_title_jira, possible_commit_jiras, source_branch_jira, expected_in_message):
+    def test_decissions_output(self, pr_title_jira, possible_commit_jiras, source_branch_jira, expected_in_message):
         result = check_dvcs.make_decisions(pr_title_jira, possible_commit_jiras, source_branch_jira)
         assert expected_in_message in result

--- a/test_check_dvcs.py
+++ b/test_check_dvcs.py
@@ -289,13 +289,13 @@ class TestMakeDecisions:
             ),
             (  # PR title does not match expected format
                 'Title title',  # it fails on mismatch instead of the PR title, is it the correct behavior?
-                [f'{check_dvcs._NO_JIRA_MARKER}', 'Title title'],
+                [f'{check_dvcs._NO_JIRA_MARKER}'],
                 f'{check_dvcs._NO_JIRA_MARKER}',
                 f"* {check_dvcs.bad_icon} Mismatch: The JIRAs in the source branch ",
             ),
-            (  # Commit is empty
+            (  # Commit does not match pr title
                 'AAP-1234',
-                [None, None],
+                ['aap-3456'],
                 f'{check_dvcs._NO_JIRA_MARKER}',
                 f"* {check_dvcs.bad_icon} Mismatch: No commit with PR title JIRA number",
             ),
@@ -305,9 +305,9 @@ class TestMakeDecisions:
                 f'{check_dvcs._NO_JIRA_MARKER}',
                 f"* {check_dvcs.bad_icon} Mismatch: No commit with source branch JIRA number",
             ),
-            (  # Commit has no JIRA
+            (  # Commit does not have _no_jira_marker
                 f"{check_dvcs._NO_JIRA_MARKER}",  # it does not show an error message for no jira commit
-                ['This is a commit', 'this is another commit', 'this is another commit'],
+                ['aap-1234'],
                 f'{check_dvcs._NO_JIRA_MARKER}',
                 f"* {check_dvcs.bad_icon} Commit Mismatch: At least one commit is required with no_jira",
             ),
@@ -319,7 +319,7 @@ class TestMakeDecisions:
             ),
             (  # Source branch does not match jira PR
                 f"{check_dvcs._NO_JIRA_MARKER}",  # results don't show a mismatch
-                ['AAP-1234', 'this is another commit aap-1234'],
+                ['AAP-1234', 'aap-1234'],
                 'AAP-1234',
                 f"* {check_dvcs.bad_icon} Mismatch: The JIRAs in the source branch",
             ),
@@ -331,19 +331,19 @@ class TestMakeDecisions:
             ),
             (  # Validate AAP-1234 marker format
                 'AAP-1234 this is a title',
-                ['AAP-1234', 'aap-1234', 'aap-1234 this is a commit with jira numbers'],
+                ['AAP-1234', 'aap-1234', 'AAp-1234'],
                 'aap-1234 this is the source branch',
                 f"* {check_dvcs.bad_icon} Mismatch: The JIRAs in the source branch",
             ),
             (  # Validate AAP-1234 marker format
                 'AAP-1234 this is a title',
-                ['AAP-1234', 'aap-1234', 'aap-1234 this is a commit with jira numbers'],
+                ['AAP-1234', 'aap-1234', 'aAp-1234'],
                 'aap-1234 this is the source branch',
                 f"* {check_dvcs.bad_icon} Mismatch: The JIRAs in the source branch",
             ),
             (  # Validate AAP-1234 marker format
                 'ABC-0900 this is a title',
-                ['ABC-0900', 'ABC-0900', 'ABC-0900 this is a commit with jira numbers'],
+                ['ABC-0900', 'ABC-0900', 'ABC-0900'],
                 'ABC-0900 this is the source branch',
                 f"* {check_dvcs.bad_icon} Mismatch: No commit with source branch JIRA number",
             ),
@@ -351,16 +351,16 @@ class TestMakeDecisions:
         ids=[
             "PR title is none",
             "PR title does not match expected format",
-            "Commit is empty",
+            "Commit does not match pr title",
             "Commit JIRA markers don't match PR and SB JIRA markers",
-            "Commit has no JIRA",
+            "Commit does not have _no_jira_marker",
             "Source branch is none",
             "Source branch does not match jira PR",
             "Source branch does not match expected format",
             "Validate AAP-1234 marker format",
             "Validate AAP-1234 marker format",
             "Validate AAP-1234 marker format",
-        ]
+        ],
     )
     def test_bad_result(self, pr_title_jira, possible_commit_jiras, source_branch_jira, expected_in_message):
         result = check_dvcs.make_decisions(pr_title_jira, possible_commit_jiras, source_branch_jira)

--- a/test_check_dvcs.py
+++ b/test_check_dvcs.py
@@ -354,6 +354,12 @@ class TestMakeDecisions:
                 'ABC-0900 this is the source branch',
                 f"* {check_dvcs.bad_icon} Mismatch: No commit with source branch JIRA number",
             ),
+            (  # Validate AAP-1234 marker format
+                'ABC-0900 this is a title',
+                [],
+                'ABC-0900 this is the source branch',
+                f"* {check_dvcs.bad_icon} Commits: No commits with a JIRA number (AAP-[0-9]+) or NO_JIRA found!"
+            ),
         ],
         ids=[
             "PR title is none",
@@ -367,6 +373,7 @@ class TestMakeDecisions:
             "Validate AAP-1234 marker format",
             "Validate AAP-1234 marker format",
             "Validate AAP-1234 marker format",
+            "Commit: no commits with a Jira number"
         ],
     )
     def test_bad_result(self, pr_title_jira, possible_commit_jiras, source_branch_jira, expected_in_message):

--- a/test_check_dvcs.py
+++ b/test_check_dvcs.py
@@ -3,7 +3,7 @@ from unittest import mock
 
 import pytest
 import requests_mock
-from requests.exceptions import MissingSchema # type: ignore
+from requests.exceptions import MissingSchema  # type: ignore
 
 import check_dvcs
 

--- a/test_check_dvcs.py
+++ b/test_check_dvcs.py
@@ -248,11 +248,6 @@ class TestMakeDecisions:
                 [f'{check_dvcs._NO_JIRA_MARKER}'],
                 f'{check_dvcs._NO_JIRA_MARKER}',
             ),
-            (
-                'AAP-5678',
-                ['AAP-5678', f"{check_dvcs._NO_JIRA_MARKER} no marker", 'AAP-5678'],
-                'aap-5678',
-            ),
         ],
     )
     def test_good_result(self, pr_title_jira, possible_commit_jiras, source_branch_jira):
@@ -334,15 +329,15 @@ class TestMakeDecisions:
                 f"* {check_dvcs.bad_icon} Mismatch: The JIRAs in the source branch",
             ),
             (  # Validate AAP-1234 marker format
-                'ABC-0900 this is a title',
-                ['ABC-0900', 'ABC-0900', 'ABC-0900'],
-                'ABC-0900 this is the source branch',
+                'AAP-3939 this is a title',
+                ['AAP-3939', 'AAP-3939', 'AAP-3939'],
+                'AAP-3939 this is the source branch',
                 f"* {check_dvcs.bad_icon} Mismatch: No commit with source branch JIRA number",
             ),
             (  # Commit: no commits with a Jira number
-                'ABC-0900 this is a title',
+                'AAP-4545 this is a title',
                 [],
-                'ABC-0900 this is the source branch',
+                'AAP-4545 this is the source branch',
                 f"* {check_dvcs.bad_icon} Commits: No commits with a JIRA number (AAP-[0-9]+) or NO_JIRA found!"
             ),
         ],

--- a/test_check_dvcs.py
+++ b/test_check_dvcs.py
@@ -23,7 +23,7 @@ class TestDoesStringStartWithJira:
     def test_does_string_start_with_jira_function(self, input, expected_return):
         result = check_dvcs.does_string_start_with_jira(input)
         assert result == expected_return
-        print('aqui', result)
+
 
 class TestGetPreviousCommentsUrls:
 

--- a/test_check_dvcs.py
+++ b/test_check_dvcs.py
@@ -3,7 +3,7 @@ from unittest import mock
 
 import pytest
 import requests_mock
-from requests.exceptions import MissingSchema
+from requests.exceptions import MissingSchema # type: ignore
 
 import check_dvcs
 
@@ -372,4 +372,3 @@ class TestMakeDecisions:
     def test_bad_result(self, pr_title_jira, possible_commit_jiras, source_branch_jira, expected_in_message):
         result = check_dvcs.make_decisions(pr_title_jira, possible_commit_jiras, source_branch_jira)
         assert expected_in_message in result
-        # print("Result from make_decisions:", result)

--- a/test_check_dvcs.py
+++ b/test_check_dvcs.py
@@ -312,26 +312,26 @@ class TestMakeDecisions:
                 f'{check_dvcs._NO_JIRA_MARKER}',
                 f"* {check_dvcs.bad_icon} Mismatch: No commit with source branch JIRA number",
             ),
-            (  # Commit does not have _no_jira_marker
+            (  # _NO_JIRA title does not care about anything else
                 f"{check_dvcs._NO_JIRA_MARKER}",  # it does not show an error message for no jira commit
                 ['aap-1234'],
-                f'{check_dvcs._NO_JIRA_MARKER}',
-                f"* {check_dvcs.bad_icon} Commit Mismatch: At least one commit is required with no_jira",
+                'aap-45657',
+                f"* {check_dvcs.good_icon} Title: reported no jira related",
             ),
             (  # Source branch is none
-                f"{check_dvcs._NO_JIRA_MARKER}",
+                "aap-1234",
                 [f'{check_dvcs._NO_JIRA_MARKER}'],
                 None,
                 f"* {check_dvcs.bad_icon} Source Branch: The source branch of the PR does not start with a JIRA number",
             ),
             (  # Source branch does not match jira PR
-                f"{check_dvcs._NO_JIRA_MARKER}",  # results don't show a mismatch
+                "aap-56788",  # results don't show a mismatch
                 ['AAP-1234', 'aap-1234'],
                 'AAP-1234',
                 f"* {check_dvcs.bad_icon} Mismatch: The JIRAs in the source branch",
             ),
             (  # Source branch does not match expected format
-                f"{check_dvcs._NO_JIRA_MARKER}",
+                "aap-1234",
                 [f'{check_dvcs._NO_JIRA_MARKER}'],
                 'ABCDE-1234',  # source accepts different types of JIRA formats.
                 f"* {check_dvcs.bad_icon} Mismatch: The JIRAs in the source branch",
@@ -366,7 +366,7 @@ class TestMakeDecisions:
             "PR title does not match expected format",
             "Commit does not match pr title",
             "Commit JIRA markers don't match PR and SB JIRA markers",
-            "Commit does not have _no_jira_marker",
+            "_NO_JIRA title does not care about anything else",
             "Source branch is none",
             "Source branch does not match jira PR",
             "Source branch does not match expected format",

--- a/test_check_dvcs.py
+++ b/test_check_dvcs.py
@@ -1,2 +1,355 @@
-def test_nothing():
-    assert True
+from os import environ
+from unittest import mock
+
+import pytest
+import requests_mock
+from requests.exceptions import MissingSchema
+
+import check_dvcs
+
+
+class TestDoesStringStartWithJira:
+
+    @pytest.mark.parametrize(
+        "input,expected_return",
+        [
+            ("testing", None),
+            (f'{check_dvcs._NO_JIRA_MARKER} other stuff', check_dvcs._NO_JIRA_MARKER),
+            ('AAP-1234 other stuff', 'AAP-1234'),
+        ],
+    )
+    def test_does_string_start_with_jira_function(self, input, expected_return):
+        result = check_dvcs.does_string_start_with_jira(input)
+        assert result == expected_return
+
+
+class TestGetPreviousCommentsUrls:
+
+    def test_invalid_url(self):
+        with pytest.raises(MissingSchema):
+            check_dvcs.get_previous_comments_urls("www.example.com")
+
+    def test_invalid_status_code(self):
+        with pytest.raises(check_dvcs.CommandException):
+            with requests_mock.Mocker() as m:
+                m.register_uri('GET', 'https://example.com', status_code=404)
+                check_dvcs.get_previous_comments_urls("https://example.com")
+
+    @pytest.mark.parametrize(
+        "json,expected_result",
+        [
+            ([], []),
+            (
+                [
+                    {
+                        "body": "This comment does not match",
+                        "url": "https://example.com/1",
+                    },
+                ],
+                [],
+            ),
+            (
+                [
+                    {
+                        "body": f"{check_dvcs.comment_preamble} This comment should match",
+                        "url": "https://example.com/1",
+                    },
+                ],
+                ["https://example.com/1"],
+            ),
+        ],
+    )
+    def test_valid_json(self, json, expected_result):
+        with requests_mock.Mocker() as m:
+            m.register_uri('GET', 'https://example.com', status_code=200, json=json)
+            response = check_dvcs.get_previous_comments_urls("https://example.com")
+            assert response == expected_result
+
+
+class TestDeletePreviousComments:
+
+    def test_good_delete(self):
+        base_url = 'https://example.com/'
+        with requests_mock.Mocker() as m:
+            m.register_uri('DELETE', f'{base_url}1', status_code=404)
+            m.register_uri('DELETE', f'{base_url}2', status_code=204)
+            check_dvcs.delete_previous_comments([f'{base_url}1', f'{base_url}2'])
+
+    def test_bad_deletes(self):
+        base_url = 'https://example.com/'
+        with requests_mock.Mocker() as m:
+            m.register_uri('DELETE', f'{base_url}1', status_code=500)
+            m.register_uri('DELETE', f'{base_url}2', status_code=201)
+            m.register_uri('DELETE', f'{base_url}3', status_code=404)
+            m.register_uri('DELETE', f'{base_url}4', status_code=204)
+            with pytest.raises(check_dvcs.CommandException) as ce:
+                check_dvcs.delete_previous_comments(
+                    [
+                        f'{base_url}1',
+                        f'{base_url}2',
+                        f'{base_url}3',
+                        f'{base_url}4',
+                    ]
+                )
+            assert f'{base_url}1' in str(ce.value)
+            assert f'{base_url}2' in str(ce.value)
+            assert f'{base_url}3' not in str(ce.value)
+            assert f'{base_url}4' not in str(ce.value)
+
+
+class TestGitCommitJiraNumbers:
+
+    def test_invalid_url(self):
+        with pytest.raises(MissingSchema):
+            check_dvcs.get_commit_jira_numbers("www.example.com")
+
+    def test_invalid_status_code(self):
+        with pytest.raises(check_dvcs.CommandException):
+            with requests_mock.Mocker() as m:
+                m.register_uri('GET', 'https://example.com', status_code=404)
+                check_dvcs.get_commit_jira_numbers("https://example.com")
+
+    @pytest.mark.parametrize(
+        "json,expected_result",
+        [
+            ([], []),
+            (
+                [
+                    {"commit": {"message": "This is wrong"}},
+                ],
+                [],
+            ),
+            (
+                [
+                    {"commit": {"message": f"{check_dvcs._NO_JIRA_MARKER} This has the no jira marker"}},
+                ],
+                [check_dvcs._NO_JIRA_MARKER],
+            ),
+            (
+                [
+                    {"commit": {"message": "AAP-1234 This has the jira marker"}},
+                ],
+                ['AAP-1234'],
+            ),
+            (
+                [
+                    {"commit": {"message": "ABC-0909 This has wrong jira marker format"}},
+                ],
+                [],
+            ),
+        ],
+    )
+    def test_json_return(self, json, expected_result):
+        with requests_mock.Mocker() as m:
+            m.register_uri('GET', 'https://example.com', status_code=200, json=json)
+            response = check_dvcs.get_commit_jira_numbers("https://example.com")
+            assert response == expected_result
+
+
+class TestMain:
+
+    @pytest.mark.parametrize(
+        "json",
+        [
+            "{'bad': 'json',}",
+            "",
+        ],
+    )
+    def test_invalid_pull_input(self, capsys, json):
+        environ['PULL_REQUEST'] = json
+        with pytest.raises(SystemExit) as e:
+            check_dvcs.main()
+        output = capsys.readouterr()
+        assert "Failed to load json from string" in output.out
+        assert e.value.code == 255
+
+    @pytest.mark.parametrize(
+        "token",
+        [
+            None,
+            "",
+        ],
+    )
+    def test_github_invalid_token(self, capsys, token):
+        environ['PULL_REQUEST'] = "{}"
+        if token:
+            environ['GH_TOKEN'] = token
+        with pytest.raises(SystemExit) as e:
+            check_dvcs.main()
+        output = capsys.readouterr()
+        assert "Did not get a github token, failing" in output.out
+        assert e.value.code == 255
+
+    def test_delete_previous_commit_fails(self, capsys):
+        environ['PULL_REQUEST'] = "{}"
+        environ['GH_TOKEN'] = "asdf1234"
+        with mock.patch('check_dvcs.get_previous_comments_urls', side_effect=check_dvcs.CommandException("Failing on purpose")):
+            with pytest.raises(SystemExit) as e:
+                check_dvcs.main()
+            output = capsys.readouterr()
+            assert "Failed to delete one or more comments" in output.out
+            assert e.value.code == 255
+
+    def test_fail_to_get_commits(self, capsys):
+        environ['PULL_REQUEST'] = '{"title": "junk"}'
+        environ['GH_TOKEN'] = "asdf1234"
+        with mock.patch('check_dvcs.get_previous_comments_urls', return_value=[]):
+            with mock.patch('check_dvcs.get_commit_jira_numbers', side_effect=check_dvcs.CommandException("Failing on purpose")):
+                with pytest.raises(SystemExit) as e:
+                    check_dvcs.main()
+                output = capsys.readouterr()
+                assert "Failed to get commits" in output.out
+                assert e.value.code == 255
+
+    def test_failed_to_add_comment(self, capsys):
+        environ['PULL_REQUEST'] = '{"title": "junk", "_links": {"comments": {"href": "https://example.com"}}}'
+        environ['GH_TOKEN'] = "asdf1234"
+        with mock.patch('check_dvcs.get_previous_comments_urls', return_value=[]):
+            with mock.patch('check_dvcs.get_commit_jira_numbers', return_value=[]):
+                with mock.patch('check_dvcs.make_decisions', return_value=""):
+                    with requests_mock.Mocker() as m:
+                        m.register_uri('POST', 'https://example.com', status_code=404)
+                        check_dvcs.main()  # We don't raise an exception for this.
+                        output = capsys.readouterr()
+                        assert "Failed to add new comment" in output.out
+
+    def test_failed_check(self):
+        environ['PULL_REQUEST'] = '{"title": "junk", "_links": {"comments": {"href": "https://example.com"}}}'
+        environ['GH_TOKEN'] = "asdf1234"
+        with mock.patch('check_dvcs.get_previous_comments_urls', return_value=[]):
+            with mock.patch('check_dvcs.get_commit_jira_numbers', return_value=[]):
+                with requests_mock.Mocker() as m:
+                    m.register_uri('POST', 'https://example.com', status_code=201)
+                    with pytest.raises(SystemExit) as e:
+                        check_dvcs.main()
+                    assert e.value.code == 255
+
+
+class TestMakeDecisions:
+
+    # test scenarios (happy path)
+    # PR has NO_JIRA_MARKER, Commit has NO_JIRA_MARKER, SB has NO_JIRA_MARKER,
+    # PR has a valid JIRA marker, commit has a valid Jira marker, SB has a valid JIRA marker
+    # Commit has _NO_JIRA_MARKER
+    # Validate upper case/lower case JIRA markers
+
+    @pytest.mark.parametrize(
+        "pr_title_jira,possible_commit_jiras,source_branch_jira",
+        [
+            (
+                f'{check_dvcs._NO_JIRA_MARKER}',
+                [f'{check_dvcs._NO_JIRA_MARKER}'],
+                f'{check_dvcs._NO_JIRA_MARKER}',
+            ),
+            (
+                'AAP-1234',
+                ['AAP-1234', f"{check_dvcs._NO_JIRA_MARKER} no marker", 'AAP-5678 Some other marker but only one has to be valid'],
+                'aap-1234',
+            ),
+            (
+                'AAP-1234',
+                ['AAP-1234', 'AAP-1234 testing valid marker', f"{check_dvcs._NO_JIRA_MARKER} Testing valid marker"],
+                'aap-1234',
+            ),
+            (
+                'AAP-1234',
+                ['AAP-1234', 'AAP-1234 testing valid marker', 'AAP-1234 testing valid marker'],
+                'aap-1234',
+            ),
+            (
+                'aap-1234',
+                ['aap-1234', 'aap-1234 testing valid marker', 'aap-1234 testing valid marker'],
+                'aap-1234',
+            ),
+        ],
+    )
+    def test_good_result(self, pr_title_jira, possible_commit_jiras, source_branch_jira):
+        result = check_dvcs.make_decisions(pr_title_jira, possible_commit_jiras, source_branch_jira)
+        assert check_dvcs.bad_icon not in result
+
+        # test scenarios (broken path)
+        # PR title is none
+        # PR title does not match expected format
+        # Commit is empty
+        # Commit JIRA markers don't match PR and SB JIRA markers
+        # Commit has no JIRA
+        # Source branch is none
+        # Source branch does not match JIRA PR
+        # Source branch does not match expected format
+        # Validate AAP-1234 marker format
+
+    @pytest.mark.parametrize(
+        "pr_title_jira,possible_commit_jiras,source_branch_jira,expected_in_message",
+        [
+            (  # PR title is none
+                None,
+                [f'{check_dvcs._NO_JIRA_MARKER}'],
+                f'{check_dvcs._NO_JIRA_MARKER}',
+                f"* {check_dvcs.bad_icon} Title: PR title does not start with a JIRA number",
+            ),
+            (  # PR title does not match expected format
+                'Title title',  # it fails on mismatch instead of the PR title, is it the correct behavior?
+                [f'{check_dvcs._NO_JIRA_MARKER}', 'Title title'],
+                f'{check_dvcs._NO_JIRA_MARKER}',
+                f"* {check_dvcs.bad_icon} Mismatch: The JIRAs in the source branch ",
+            ),
+            (  # Commit is empty
+                'AAP-1234',
+                [None, None],
+                f'{check_dvcs._NO_JIRA_MARKER}',
+                f"* {check_dvcs.bad_icon} Mismatch: No commit with PR title JIRA number",
+            ),
+            (  # Commit JIRA markers don't match PR and SB JIRA markers
+                'AAP-1234',
+                ['AAP-1235', 'AAP-1235'],
+                f'{check_dvcs._NO_JIRA_MARKER}',
+                f"* {check_dvcs.bad_icon} Mismatch: No commit with source branch JIRA number",
+            ),
+            (  # Commit has no JIRA
+                f"{check_dvcs._NO_JIRA_MARKER}",  # it does not show an error message for no jira commit
+                ['This is a commit', 'this is another commit', 'this is another commit'],
+                f'{check_dvcs._NO_JIRA_MARKER}',
+                f"* {check_dvcs.bad_icon} / not the result ?",
+            ),
+            (  # Source branch is none
+                f"{check_dvcs._NO_JIRA_MARKER}",
+                [f'{check_dvcs._NO_JIRA_MARKER}'],
+                None,
+                f"* {check_dvcs.bad_icon} Source Branch: The source branch of the PR does not start with a JIRA number",
+            ),
+            (  # Source branch does not match jira PR
+                f"{check_dvcs._NO_JIRA_MARKER}",  # results don't show a mismatch
+                ['AAP-1234', 'this is another commit aap-1234'],
+                'AAP-1234',
+                f"* {check_dvcs.bad_icon} Mismatch: The JIRAs in the source branch",
+            ),
+            (  # Source branch does not match expected format
+                f"{check_dvcs._NO_JIRA_MARKER}",
+                [f'{check_dvcs._NO_JIRA_MARKER}'],
+                'ABCDE-1234',  # source accepts different types of JIRA formats.
+                f"* {check_dvcs.bad_icon} Source Branch: The source branch of the PR does not start with",
+            ),
+            (  # Validate AAP-1234 marker format
+                'AAP-1234 this is a title',
+                ['AAP-1234', 'aap-1234', 'aap-1234 this is a commit with jira numbers'],
+                'aap-1234 this is the source branch',
+                f"* {check_dvcs.bad_icon} Mismatch: The JIRAs in the source branch",
+            ),
+            (  # Validate AAP-1234 marker format
+                'AAP-1234 this is a title',
+                ['AAP-1234', 'aap-1234', 'aap-1234 this is a commit with jira numbers'],
+                'aap-1234 this is the source branch',
+                f"* {check_dvcs.bad_icon} Mismatch: The JIRAs in the source branch",
+            ),
+            (  # Validate AAP-1234 marker format
+                'ABC-0900 this is a title',
+                ['ABC-0900', 'ABC-0900', 'ABC-0900 this is a commit with jira numbers'],
+                'ABC-0900 this is the source branch',
+                f"* {check_dvcs.bad_icon} Mismatch: No commit with source branch JIRA number",
+            ),
+        ],
+    )
+    def test_bad_result(self, pr_title_jira, possible_commit_jiras, source_branch_jira, expected_in_message):
+        result = check_dvcs.make_decisions(pr_title_jira, possible_commit_jiras, source_branch_jira)
+        assert expected_in_message in result
+        # print("Result from make_decisions:", result)

--- a/test_check_dvcs.py
+++ b/test_check_dvcs.py
@@ -68,11 +68,17 @@ class TestGetPreviousCommentsUrls:
 
 class TestDeletePreviousComments:
 
+    def test_missing_header(self):
+        with pytest.raises(check_dvcs.CommandException) as ce:
+            check_dvcs.delete_previous_comments([])
+        assert 'Auth header missing' in str(ce.value)
+
     def test_good_delete(self):
         base_url = 'https://example.com/'
         with requests_mock.Mocker() as m:
             m.register_uri('DELETE', f'{base_url}1', status_code=404)
             m.register_uri('DELETE', f'{base_url}2', status_code=204)
+            check_dvcs.http_headers['Authorization'] = 'Bearer 1234'
             check_dvcs.delete_previous_comments([f'{base_url}1', f'{base_url}2'])
 
     def test_bad_deletes(self):
@@ -83,6 +89,7 @@ class TestDeletePreviousComments:
             m.register_uri('DELETE', f'{base_url}3', status_code=404)
             m.register_uri('DELETE', f'{base_url}4', status_code=204)
             with pytest.raises(check_dvcs.CommandException) as ce:
+                check_dvcs.http_headers['Authorization'] = 'Bearer 1234'
                 check_dvcs.delete_previous_comments(
                     [
                         f'{base_url}1',

--- a/test_check_dvcs.py
+++ b/test_check_dvcs.py
@@ -354,7 +354,7 @@ class TestMakeDecisions:
                 'ABC-0900 this is the source branch',
                 f"* {check_dvcs.bad_icon} Mismatch: No commit with source branch JIRA number",
             ),
-            (  # Validate AAP-1234 marker format
+            (  # Commit: no commits with a Jira number
                 'ABC-0900 this is a title',
                 [],
                 'ABC-0900 this is the source branch',

--- a/test_check_dvcs.py
+++ b/test_check_dvcs.py
@@ -309,7 +309,7 @@ class TestMakeDecisions:
                 f"{check_dvcs._NO_JIRA_MARKER}",  # it does not show an error message for no jira commit
                 ['This is a commit', 'this is another commit', 'this is another commit'],
                 f'{check_dvcs._NO_JIRA_MARKER}',
-                f"* {check_dvcs.bad_icon} / not the result ?",
+                f"* {check_dvcs.bad_icon} Commit Mismatch: At least one commit is required with no_jira",
             ),
             (  # Source branch is none
                 f"{check_dvcs._NO_JIRA_MARKER}",
@@ -327,7 +327,7 @@ class TestMakeDecisions:
                 f"{check_dvcs._NO_JIRA_MARKER}",
                 [f'{check_dvcs._NO_JIRA_MARKER}'],
                 'ABCDE-1234',  # source accepts different types of JIRA formats.
-                f"* {check_dvcs.bad_icon} Source Branch: The source branch of the PR does not start with",
+                f"* {check_dvcs.bad_icon} Mismatch: The JIRAs in the source branch",
             ),
             (  # Validate AAP-1234 marker format
                 'AAP-1234 this is a title',
@@ -348,6 +348,19 @@ class TestMakeDecisions:
                 f"* {check_dvcs.bad_icon} Mismatch: No commit with source branch JIRA number",
             ),
         ],
+        ids=[
+            "PR title is none",
+            "PR title does not match expected format",
+            "Commit is empty",
+            "Commit JIRA markers don't match PR and SB JIRA markers",
+            "Commit has no JIRA",
+            "Source branch is none",
+            "Source branch does not match jira PR",
+            "Source branch does not match expected format",
+            "Validate AAP-1234 marker format",
+            "Validate AAP-1234 marker format",
+            "Validate AAP-1234 marker format",
+        ]
     )
     def test_bad_result(self, pr_title_jira, possible_commit_jiras, source_branch_jira, expected_in_message):
         result = check_dvcs.make_decisions(pr_title_jira, possible_commit_jiras, source_branch_jira)


### PR DESCRIPTION
Recreating the [PR](https://github.com/ansible/dvcs-action/pull/3) 

* Renaming Branch to AAP-35593
* Adding unit tests to dvcs checks