### PR TITLE
AAP-38102 Rework and simplify dvcs check

### DIFF
--- a/check_dvcs.py
+++ b/check_dvcs.py
@@ -12,8 +12,6 @@ import requests
 _NO_JIRA_MARKER = "NO_JIRA"
 _AAP_RE = "AAP-[0-9]+"
 comment_preamble = "DVCS PR Check Results:"
-good_icon = "✅"
-bad_icon = "❌"
 http_headers = {
     "Accept": "application/vnd.github+json",
     "X-GitHub-Api-Version": "2022-11-28",
@@ -186,10 +184,11 @@ def main(args=[]):
 
     pr_is_valid = does_pr_reference_ticket(pr_title_jira, possible_commit_jiras, source_branch_jira)
 
+    new_comment_body = comment_preamble
     if pr_is_valid:
-        new_comment_body = "PR appears valid (JIRA key(s) found)"
+        new_comment_body += "\n\nPR appears valid (JIRA key(s) found)"
     else:
-        new_comment_body = "Could not find JIRA key(s) in PR title, branch name, or commit messages"
+        new_comment_body += "\n\nCould not find JIRA key(s) in PR title, branch name, or commit messages"
 
     # Post the new comment
     if not dry_run:

--- a/check_dvcs.py
+++ b/check_dvcs.py
@@ -10,7 +10,7 @@ from typing import Optional
 import requests
 
 _NO_JIRA_MARKER = "NO_JIRA"
-_AAP_RE = "aap-[0-9]+"
+_AAP_RE = "AAP-[0-9]+"
 comment_preamble = "DVCS PR Check Results:"
 good_icon = "✅"
 bad_icon = "❌"
@@ -60,10 +60,10 @@ def delete_previous_comments(comments_urls: list[str]) -> None:
         raise CommandException('\n'.join(comments_that_failed_to_delete))
 
 
-def does_string_start_with_jira(string_to_match: str) -> Optional[str]:
-    pr_title_re = re.compile(f"^({_AAP_RE}|{_NO_JIRA_MARKER})", re.IGNORECASE)
+def does_string_contain_jira(string_to_match: str) -> Optional[str]:
+    pr_title_re = re.compile(f"({_AAP_RE}|{_NO_JIRA_MARKER})")
     matches = pr_title_re.match(string_to_match)
-    print(f"Checking if {string_to_match} starts with our RE ... ", end="")
+    print(f"Checking if {string_to_match} contains our RE ... ", end="")
     if not matches:
         print("Failed!")
         return None
@@ -78,7 +78,7 @@ def get_commit_jira_numbers(commit_url: str) -> list[str]:
     print(commits.status_code)
     if commits.status_code != 200:
         raise CommandException("Failed to get commits!")
-    comment_re = re.compile(rf"({_AAP_RE}|{_NO_JIRA_MARKER})", re.IGNORECASE)
+    comment_re = re.compile(rf"({_AAP_RE}|{_NO_JIRA_MARKER})")
     possible_jiras = []
     for commit in commits.json():
         # TODO: How to check if this is a merge commit or a regular comment?
@@ -93,84 +93,40 @@ def get_commit_jira_numbers(commit_url: str) -> list[str]:
     return possible_jiras
 
 
-def make_decisions(
+def does_pr_reference_ticket(
     pr_title_jira: Optional[str],
     possible_commit_jiras: list[str],
     source_branch_jira: Optional[str],
-) -> str:
-    # Lower case everything for comparison
-    if pr_title_jira is not None:
-        pr_title_jira = pr_title_jira.lower()
-    if source_branch_jira is not None:
-        source_branch_jira = source_branch_jira.lower()
-    for index in range(0, len(possible_commit_jiras)):
-        if possible_commit_jiras[index] is not None:
-            possible_commit_jiras[index] = possible_commit_jiras[index].lower()
+) -> bool:
+    """
+    Does the PR reference at least one JIRA ticket?
+
+    Although it seems to be sparsely documented, the JIRA "DVCS" plugin expects
+    *at least one* of the following:
+
+    - A ticket key (AAP-nnnnnn) in the PR title
+    - A ticket key in the branch name
+    - A ticket key in a commit message in the set of commits in the PR
+
+    It seems there is no notion of conflict handling: If multiple different
+    ticket keys are found, it will simply attach the PR to all referenced
+    tickets.
+    """
 
     print("")
-    print("Making decisions based on the following:")
+    print("Checking validity based on the following:")
     print(f"JIRA from title: {pr_title_jira}")
     print(f"JIRA from source branch: {source_branch_jira}")
     print(f"JIRAS from commits: {', '.join(possible_commit_jiras)}")
     print("")
 
-    decisions = [comment_preamble]
-    # Now make th decisions if this is in good order....
-
-    # First check the PR title
-    if not pr_title_jira:
-        # If there is no PR title JIRA report bad
-        decisions.append(f"* {bad_icon} Title: PR title does not start with a JIRA number (AAP-[0-9]+) or {_NO_JIRA_MARKER}")
-    elif pr_title_jira == _NO_JIRA_MARKER.lower():
-        # If we put the _NO_JIRA_MARKER in the title that is good enough.
-        # it provides the lowest entry barrier for community as they wouldn't have to fix branches or commit messages
-        decisions.append(f"* {good_icon} Title: reported no jira related, no other checks necessary")
-        return "\n".join(decisions)
-    else:
-        # Report the title is good
-        decisions.append(f"* {good_icon} Title: JIRA number {pr_title_jira}")
-
-    # Next check the source branch
-    if not source_branch_jira:
-        # If there is no Source Branch JIRA report bad
-        decisions.append(f"* {bad_icon} Source Branch: The source branch of the PR does not start with a JIRA number (AAP-[0-9]+) or {_NO_JIRA_MARKER}")
-    else:
-        # Report the source branch is good
-        decisions.append(f"* {good_icon} Source Branch: JIRA number {source_branch_jira}")
-
-    # Now compare the source branch to the pr title
-    if pr_title_jira is not None and source_branch_jira is not None and pr_title_jira != source_branch_jira:
-        # If we have source and title JIRAS and there is a mismatch between the title and source branch JIRAs report the mismatch
-        decisions.append(f"* {bad_icon} Mismatch: The JIRAs in the source branch {source_branch_jira} and title {pr_title_jira} do not match!")
-
-    # Finally lets check the commits
-    if len(possible_commit_jiras) == 0:
-        # If we got no commit JIRAS the commits are bad
-        decisions.append(f"* {bad_icon} Commits: No commits with a JIRA number (AAP-[0-9]+) or {_NO_JIRA_MARKER} found!")
-    elif source_branch_jira == pr_title_jira:
-        if source_branch_jira is None:
-            # If the source branch JIRA and the title JIRA are missing and we have commit JIRAS report the commits as good
-            decisions.append(f"* {good_icon} Commits: At least one JIRA number in commit messages {', '.join(possible_commit_jiras)}")
-        else:
-            # If the source branch JIRA matches the title JIRA and we have that JIRA in the commits, the commits are good
-            if source_branch_jira in possible_commit_jiras:
-                decisions.append(f"* {good_icon} Commits: At least one JIRA number in commit messages match the other JIRA numbers")
-            else:
-                decisions.append(f"* {bad_icon} Commit Mismatch: At least one commit is required with {source_branch_jira}")
-    else:
-        # If we made it here, we have commit JIRAS but we have a mismatch between the source branch and title
-        if source_branch_jira is not None and source_branch_jira not in possible_commit_jiras:
-            decisions.append(f"* {bad_icon} Mismatch: No commit with source branch JIRA number")
-        if pr_title_jira is not None and pr_title_jira not in possible_commit_jiras:
-            decisions.append(f"* {bad_icon} Mismatch: No commit with PR title JIRA number")
-
-    # Construct the new comment
-    return "\n".join(decisions)
+    # PR title or source branch is truthy means we found a regex match on the
+    # ticket key
+    # A non-empty possible_commit_jiras means at least one commit matched
+    return any([pr_title_jira, source_branch_jira, possible_commit_jiras])
 
 
 def main(args=[]):
-    global http_headers
-
     dry_run = False
 
     parser = argparse.ArgumentParser(
@@ -214,22 +170,26 @@ def main(args=[]):
             exit(255)
 
     # Check the PR title
-    pr_title_jira = does_string_start_with_jira(pull_request.get("title"))
+    pr_title_jira = does_string_contain_jira(pull_request.get("title"))
 
     # Check the PR commits
     try:
         possible_commit_jiras = get_commit_jira_numbers(pull_urls.get("commits", {}).get("href"))
     except CommandException as ce:
+        # Don't fail out in this case, if we already found a JIRA key, we might
+        # not even care about commits here.
         print(f"Failed to get commits: {ce}")
-        exit(255)
+        possible_commit_jiras = []
 
     # Check the PR source branch
-    source_branch_jira = does_string_start_with_jira(pull_request.get("head", {}).get("ref", ""))
+    source_branch_jira = does_string_contain_jira(pull_request.get("head", {}).get("ref", ""))
 
-    new_comment_body = make_decisions(pr_title_jira, possible_commit_jiras, source_branch_jira)
+    pr_is_valid = does_pr_reference_ticket(pr_title_jira, possible_commit_jiras, source_branch_jira)
 
-    print("Results:")
-    print(new_comment_body)
+    if pr_is_valid:
+        new_comment_body = "PR appears valid (JIRA key(s) found)"
+    else:
+        new_comment_body = "Could not find JIRA key(s) in PR title, branch name, or commit messages"
 
     # Post the new comment
     if not dry_run:
@@ -239,9 +199,7 @@ def main(args=[]):
         if response.status_code != 201:
             print("Failed to add new comment")
 
-    # If we had any errors, print them and exit
-    if bad_icon in new_comment_body:
-        exit(255)
+    exit(0 if pr_is_valid else 255)
 
 
 if __name__ == '__main__':

--- a/check_dvcs.py
+++ b/check_dvcs.py
@@ -60,7 +60,7 @@ def delete_previous_comments(comments_urls: list[str]) -> None:
 
 def does_string_contain_jira(string_to_match: str) -> Optional[str]:
     pr_title_re = re.compile(f"({_AAP_RE}|{_NO_JIRA_MARKER})")
-    matches = pr_title_re.match(string_to_match)
+    matches = pr_title_re.search(string_to_match)
     print(f"Checking if {string_to_match} contains our RE ... ", end="")
     if not matches:
         print("Failed!")
@@ -80,7 +80,7 @@ def get_commit_jira_numbers(commit_url: str) -> list[str]:
     possible_jiras = []
     for commit in commits.json():
         # TODO: How to check if this is a merge commit or a regular comment?
-        matches = comment_re.match(commit["commit"]["message"])
+        matches = comment_re.search(commit["commit"]["message"])
         print(f"Checking if {commit['commit']['message']} has a JIRA number in it ... ", end="")
         if matches:
             print(f"Good: {matches.groups()[0]}")

--- a/test_check_dvcs.py
+++ b/test_check_dvcs.py
@@ -8,7 +8,7 @@ from requests.exceptions import MissingSchema  # type: ignore
 import check_dvcs
 
 
-class TestDoesStringStartWithJira:
+class TestDoesStringContainJira:
 
     @pytest.mark.parametrize(
         "input,expected_return",
@@ -20,8 +20,8 @@ class TestDoesStringStartWithJira:
             ('other stuff AAP-4444 jira in the middle', None),
         ],
     )
-    def test_does_string_start_with_jira_function(self, input, expected_return):
-        result = check_dvcs.does_string_start_with_jira(input)
+    def test_does_string_contain_jira_function(self, input, expected_return):
+        result = check_dvcs.does_string_contain_jira(input)
         assert result == expected_return
 
 
@@ -200,27 +200,36 @@ class TestMain:
             assert e.value.code == 255
 
     def test_fail_to_get_commits(self, capsys):
+        """
+        If we fail to get commits, don't bail out - we might have found a JIRA
+        key in the PR title or branch name that we can use instead. But still
+        report the failure to stdout.
+        """
         environ['PULL_REQUEST'] = '{"title": "junk"}'
         environ['GH_TOKEN'] = "asdf1234"
         with mock.patch('check_dvcs.get_previous_comments_urls', return_value=[]):
             with mock.patch('check_dvcs.get_commit_jira_numbers', side_effect=check_dvcs.CommandException("Failing on purpose")):
-                with pytest.raises(SystemExit) as e:
-                    check_dvcs.main()
+                with mock.patch('check_dvcs.requests.post'):
+                    try:
+                        check_dvcs.main()
+                    except SystemExit:
+                        pass  # We get to the end... This isn't what we're testing for.
                 output = capsys.readouterr()
                 assert "Failed to get commits" in output.out
-                assert e.value.code == 255
 
     def test_failed_to_add_comment(self, capsys):
         environ['PULL_REQUEST'] = '{"title": "junk", "_links": {"comments": {"href": "https://example.com"}}}'
         environ['GH_TOKEN'] = "asdf1234"
         with mock.patch('check_dvcs.get_previous_comments_urls', return_value=[]):
             with mock.patch('check_dvcs.get_commit_jira_numbers', return_value=[]):
-                with mock.patch('check_dvcs.make_decisions', return_value=""):
+                with mock.patch('check_dvcs.does_pr_reference_ticket', return_value=True):
                     with requests_mock.Mocker() as m:
                         m.register_uri('POST', 'https://example.com', status_code=404)
-                        check_dvcs.main()  # We don't raise an exception for this.
+                        with pytest.raises(SystemExit) as e:
+                            check_dvcs.main()  # We don't raise an exception for this, we exit normally
                         output = capsys.readouterr()
                         assert "Failed to add new comment" in output.out
+                        assert e.value.code == 0
 
     def test_failed_check(self):
         environ['PULL_REQUEST'] = '{"title": "junk", "_links": {"comments": {"href": "https://example.com"}}}'
@@ -234,128 +243,84 @@ class TestMain:
                     assert e.value.code == 255
 
 
-class TestMakeDecisions:
-
-    # test scenarios (happy path)
-    # PR has NO_JIRA_MARKER, Commit has NO_JIRA_MARKER, SB has NO_JIRA_MARKER,
-    # PR has a valid JIRA marker, commit has a valid Jira marker, SB has a valid JIRA marker
-
+class TestDoesPrReferenceTicket:
     @pytest.mark.parametrize(
-        "pr_title_jira,possible_commit_jiras,source_branch_jira",
+        "pr_title_jira, possible_commit_jiras, source_branch_jira, expected_result",
         [
-            (
-                f'{check_dvcs._NO_JIRA_MARKER}',
-                [f'{check_dvcs._NO_JIRA_MARKER}'],
-                f'{check_dvcs._NO_JIRA_MARKER}',
-            ),
-        ],
-    )
-    def test_good_result(self, pr_title_jira, possible_commit_jiras, source_branch_jira):
-        result = check_dvcs.make_decisions(pr_title_jira, possible_commit_jiras, source_branch_jira)
-        assert check_dvcs.bad_icon not in result
-
-        # test scenarios (broken path)
-        # PR title is none
-        # PR title does not match expected format
-        # Commit is empty
-        # Commit JIRA markers don't match PR and SB JIRA markers
-        # Commit has no JIRA
-        # Source branch is none
-        # Source branch does not match JIRA PR
-        # Source branch does not match expected format
-        # Validate AAP-1234 marker format
-
-    @pytest.mark.parametrize(
-        "pr_title_jira,possible_commit_jiras,source_branch_jira,expected_in_message",
-        [
-            (  # PR title is none
+            (  # No key in PR title, commits and source branch both have NO_JIRA
                 None,
                 [f'{check_dvcs._NO_JIRA_MARKER}'],
                 f'{check_dvcs._NO_JIRA_MARKER}',
-                f"* {check_dvcs.bad_icon} Title: PR title does not start with a JIRA number",
+                True,
             ),
-            (  # PR title does not match expected format
-                'Title title',  # it fails on mismatch instead of the PR title, is it the correct behavior?
-                [f'{check_dvcs._NO_JIRA_MARKER}'],
-                f'{check_dvcs._NO_JIRA_MARKER}',
-                f"* {check_dvcs.bad_icon} Mismatch: The JIRAs in the source branch ",
-            ),
-            (  # Commit does not match pr title
-                'AAP-1234',
-                ['aap-3456'],
-                f'{check_dvcs._NO_JIRA_MARKER}',
-                f"* {check_dvcs.bad_icon} Mismatch: No commit with PR title JIRA number",
-            ),
-            (  # Commit JIRA markers don't match PR and SB JIRA markers
+            (  # Key in PR title, multiple in commits, key in branch name
                 'AAP-1234',
                 ['AAP-1235', 'AAP-1235'],
-                f'{check_dvcs._NO_JIRA_MARKER}',
-                f"* {check_dvcs.bad_icon} Mismatch: No commit with source branch JIRA number",
+                'AAP-1234',
+                True,
             ),
-            (  # _NO_JIRA title does not care about anything else
-                f"{check_dvcs._NO_JIRA_MARKER}",  # it does not show an error message for no jira commit
-                ['aap-1234'],
-                'aap-45657',
-                f"* {check_dvcs.good_icon} Title: reported no jira related",
+            (  # NO_JIRA in PR title, keys in commits and source branch
+                f"{check_dvcs._NO_JIRA_MARKER}",
+                ['AAP-1234'],
+                'AAP-45657',
+                True,
             ),
-            (  # Source branch is none
-                "aap-1234",
+            (  # Key in PR title and commit, not in branch name
+                "AAP-1234",
                 [f'{check_dvcs._NO_JIRA_MARKER}'],
                 None,
-                f"* {check_dvcs.bad_icon} Source Branch: The source branch of the PR does not start with a JIRA number",
+                True,
             ),
             (  # Source branch does not match jira PR
-                "aap-56788",  # results don't show a mismatch
-                ['AAP-1234', 'aap-1234'],
+                "AAP-56788",
+                ['AAP-1234', 'AAP-1234'],
                 'AAP-1234',
-                f"* {check_dvcs.bad_icon} Mismatch: The JIRAs in the source branch",
+                True,
             ),
-            (  # Source branch does not match expected format
-                "aap-1234",
-                [f'{check_dvcs._NO_JIRA_MARKER}'],
-                'ABCDE-1234',  # source accepts different types of JIRA formats.
-                f"* {check_dvcs.bad_icon} Mismatch: The JIRAs in the source branch",
-            ),
-            (  # Validate low and upper case AAP-1234 marker format
-                'AAP-9009 this is a title',
-                ['AAP-9009', 'aap-9009', 'AAp-9009'],
-                'aap-9009 this is the source branch',
-                f"* {check_dvcs.bad_icon} Mismatch: The JIRAs in the source branch",
-            ),
-            (  # Validate AAP-1234 same marker format
-                'AAP-1234 this is a title',
-                ['AAP-1234', 'aap-1234', 'aAp-1234'],
-                'aap-1234 this is the source branch',
-                f"* {check_dvcs.bad_icon} Mismatch: The JIRAs in the source branch",
-            ),
-            (  # Validate AAP-1234 marker format
-                'AAP-3939 this is a title',
-                ['AAP-3939', 'AAP-3939', 'AAP-3939'],
-                'AAP-3939 this is the source branch',
-                f"* {check_dvcs.bad_icon} Mismatch: No commit with source branch JIRA number",
-            ),
-            (  # Commit: no commits with a Jira number
-                'AAP-4545 this is a title',
+            (  # Key in PR title and branch name, not in commit
+                "AAP-1234",
                 [],
-                'AAP-4545 this is the source branch',
-                f"* {check_dvcs.bad_icon} Commits: No commits with a JIRA number (AAP-[0-9]+) or NO_JIRA found!"
+                'AAP-1235',
+                True,
+            ),
+            (  # Key only in PR title
+                'AAP-9009',
+                [],
+                None,
+                True,
+            ),
+            (  # Key only in commit
+                None,
+                ['AAP-93993'],
+                None,
+                True,
+            ),
+            (  # Key only in PR title
+                None,
+                [],
+                'AAP-77888',
+                True,
+            ),
+            (  # No key in PR title, branch name, or commit.
+                None,
+                [],
+                None,
+                False,
             ),
         ],
         ids=[
-            "PR title is none",
-            "PR title does not match expected format",
-            "Commit does not match pr title",
-            "Commit JIRA markers don't match PR and SB JIRA markers",
-            "_NO_JIRA title does not care about anything else",
-            "Source branch is none",
+            "No key in PR title, commits and source branch both have NO_JIRA",
+            "Key in PR title, multiple in commits, key in branch name",
+            "NO_JIRA in PR title, keys in commits and source branch",
+            "Key in PR title and commit, not in branch name",
             "Source branch does not match jira PR",
-            "Source branch does not match expected format",
-            "Validate low and upper case AAP-1234 marker format",
-            "Validate AAP-1234 same marker format",
-            "Validate AAP-1234 marker format",
-            "Commit: no commits with a Jira number"
+            "Key in PR title and branch name, not in commit",
+            "Key only in PR title",
+            "Key only in commit",
+            "Key only in PR title",
+            "No key in PR title, branch name, or commit.",
         ],
     )
-    def test_decissions_output(self, pr_title_jira, possible_commit_jiras, source_branch_jira, expected_in_message):
-        result = check_dvcs.make_decisions(pr_title_jira, possible_commit_jiras, source_branch_jira)
-        assert expected_in_message in result
+    def test_decisions_output(self, pr_title_jira, possible_commit_jiras, source_branch_jira, expected_result):
+        result = check_dvcs.does_pr_reference_ticket(pr_title_jira, possible_commit_jiras, source_branch_jira)
+        assert result == expected_result

--- a/test_check_dvcs.py
+++ b/test_check_dvcs.py
@@ -327,6 +327,6 @@ class TestDoesPrReferenceTicket:
             "No key in PR title, branch name, or commit.",
         ],
     )
-    def test_decisions_output(self, pr_title_jira, possible_commit_jiras, source_branch_jira, expected_result):
+    def test_does_pr_reference_ticket(self, pr_title_jira, possible_commit_jiras, source_branch_jira, expected_result):
         result = check_dvcs.does_pr_reference_ticket(pr_title_jira, possible_commit_jiras, source_branch_jira)
         assert result == expected_result

--- a/test_check_dvcs.py
+++ b/test_check_dvcs.py
@@ -16,8 +16,9 @@ class TestDoesStringContainJira:
             ("testing", None),
             (f'{check_dvcs._NO_JIRA_MARKER} other stuff', check_dvcs._NO_JIRA_MARKER),
             ('AAP-2222 other stuff', 'AAP-2222'),
-            ('other stuff AAP-3333', None),
-            ('other stuff AAP-4444 jira in the middle', None),
+            ('other stuff AAP-3333', 'AAP-3333'),
+            ('other stuff AAP-4444 jira in the middle', 'AAP-4444'),
+            ('a-hoopy-AAP-9999-frood', 'AAP-9999'),
         ],
     )
     def test_does_string_contain_jira_function(self, input, expected_return):
@@ -244,6 +245,7 @@ class TestMain:
 
 
 class TestDoesPrReferenceTicket:
+
     @pytest.mark.parametrize(
         "pr_title_jira, possible_commit_jiras, source_branch_jira, expected_result",
         [

--- a/test_check_dvcs.py
+++ b/test_check_dvcs.py
@@ -19,6 +19,10 @@ class TestDoesStringContainJira:
             ('other stuff AAP-3333', 'AAP-3333'),
             ('other stuff AAP-4444 jira in the middle', 'AAP-4444'),
             ('a-hoopy-AAP-9999-frood', 'AAP-9999'),
+            ('a-hoopy-aap-9999-frood', None),
+            ('aap-9999 hey', None),
+            ('Aap-9999 hey', None),
+            ('AAP-9999 hey', 'AAP-9999'),
         ],
     )
     def test_does_string_contain_jira_function(self, input, expected_return):


### PR DESCRIPTION
- Only one of {PR title, branch name, commit messages} must contain
  a Jira key.
- Multiple Jira keys are fine, the DVCS just links them to multiple
  tickets.
- Remove a bunch of logic around "mismatches" for multiple Jira keys.
- Fix regex to not be case-insensitive.
- Ensure the Jira key can appear anywhere in the haystack strings.
- Rework tests for the above

Signed-off-by: Rick Elrod <rick@elrod.me>